### PR TITLE
added additional check in IsDynamic extension method

### DIFF
--- a/OdinSerializer/Utilities/Misc/AssemblyUtilities.cs
+++ b/OdinSerializer/Utilities/Misc/AssemblyUtilities.cs
@@ -419,7 +419,7 @@ namespace OdinSerializer.Utilities
         public static bool IsDynamic(this Assembly assembly)
         {
             if (assembly == null) throw new ArgumentNullException("assembly");
-            return assembly.GetType().Name == "AssemblyBuilder";
+            return assembly.GetType().Name == "AssemblyBuilder" || assembly.IsDynamic;
         }
 
         /// <summary>


### PR DESCRIPTION
the following code will throw an exception if assembly.IsDyamic property value is true:

if (assembly.CodeBase == null) return null;