### PR TITLE
Add options to do partial AOT project scan

### DIFF
--- a/OdinSerializer/Unity Integration/AOTSupportScanner.cs
+++ b/OdinSerializer/Unity Integration/AOTSupportScanner.cs
@@ -136,8 +136,13 @@ namespace OdinSerializer.Editor
             return true;
         }
 
-        public bool ScanAllResources(bool includeResourceDependencies, bool showProgressBar)
+        public bool ScanAllResources(bool includeResourceDependencies, bool showProgressBar, List<string> resourcesPaths = null)
         {
+            if (resourcesPaths == null)
+            {
+                resourcesPaths = new List<string>() {""};
+            }
+
             try
             {
                 if (showProgressBar && EditorUtility.DisplayCancelableProgressBar("Scanning resources for AOT support", "Loading resource assets", 0f))
@@ -145,7 +150,20 @@ namespace OdinSerializer.Editor
                     return false;
                 }
 
-                var resources = Resources.LoadAll("");
+                var resourcesSet = new HashSet<UnityEngine.Object>();
+                for (int i = 0; i < resourcesPaths.Count; i++)
+                {
+                    var resourcesPath = resourcesPaths[i];
+
+                    if (showProgressBar && EditorUtility.DisplayCancelableProgressBar("Listing resources for AOT support", resourcesPath, (float)i / resourcesPaths.Count))
+                    {
+                        return false;
+                    }
+
+                    resourcesSet.UnionWith(Resources.LoadAll(resourcesPath));
+                }
+
+                var resources = resourcesSet.ToArray();
 
                 for (int i = 0; i < resources.Length; i++)
                 {

--- a/OdinSerializer/Unity Integration/AOTSupportUtilities.cs
+++ b/OdinSerializer/Unity Integration/AOTSupportUtilities.cs
@@ -38,12 +38,13 @@ namespace OdinSerializer.Editor
         /// Scans the project's build scenes and resources, plus their dependencies, for serialized types to support. Progress bars are shown during the scan.
         /// </summary>
         /// <param name="serializedTypes">The serialized types to support.</param>
-        /// <param name="scanBuildScenes">Whether to scan the build scenes.</param>
-        /// <param name="resourcesToScan">An optional list of the resource paths to scan. All the resources will be scanned if null.</param>
-        /// <param name="scanAllAssetBundles">Whether to scan all the asset bundles.</param>
-        /// <param name="scanPreloadedAssets">Whether to scan the preloaded assets.</param>
+        /// <param name="scanBuildScenes">Whether to scan the project's build scenes.</param>
+        /// <param name="scanAllAssetBundles">Whether to scan all the project's asset bundles.</param>
+        /// <param name="scanPreloadedAssets">Whether to scan the project's preloaded assets.</param>
+        /// <param name="scanResources">Whether to scan the project's resources.</param>
+        /// <param name="resourcesToScan">An optional list of the resource paths to scan. Only has an effect if the scanResources argument is true. All the resources will be scanned if null.</param>
         /// <returns>true if the scan succeeded, false if the scan failed or was cancelled</returns>
-        public static bool ScanProjectForSerializedTypes(out List<Type> serializedTypes, bool scanBuildScenes = true, List<string> resourcesToScan = null, bool scanAllAssetBundles = true, bool scanPreloadedAssets = true)
+        public static bool ScanProjectForSerializedTypes(out List<Type> serializedTypes, bool scanBuildScenes = true, bool scanAllAssetBundles = true, bool scanPreloadedAssets = true, bool scanResources = true, List<string> resourcesToScan = null)
         {
             using (var scanner = new AOTSupportScanner())
             {
@@ -56,7 +57,7 @@ namespace OdinSerializer.Editor
                     return false;
                 }
 
-                if (!scanner.ScanAllResources(includeResourceDependencies: true, showProgressBar: true, resourcesPaths: resourcesToScan))
+                if (scanResources && !scanner.ScanAllResources(includeResourceDependencies: true, showProgressBar: true, resourcesPaths: resourcesToScan))
                 {
                     Debug.Log("Project scan canceled while scanning resources and their depencencies.");
                     serializedTypes = null;

--- a/OdinSerializer/Unity Integration/AOTSupportUtilities.cs
+++ b/OdinSerializer/Unity Integration/AOTSupportUtilities.cs
@@ -38,35 +38,39 @@ namespace OdinSerializer.Editor
         /// Scans the project's build scenes and resources, plus their dependencies, for serialized types to support. Progress bars are shown during the scan.
         /// </summary>
         /// <param name="serializedTypes">The serialized types to support.</param>
+        /// <param name="scanBuildScenes">Whether to scan the build scenes.</param>
+        /// <param name="resourcesToScan">An optional list of the resource paths to scan. All the resources will be scanned if null.</param>
+        /// <param name="scanAllAssetBundles">Whether to scan all the asset bundles.</param>
+        /// <param name="scanPreloadedAssets">Whether to scan the preloaded assets.</param>
         /// <returns>true if the scan succeeded, false if the scan failed or was cancelled</returns>
-        public static bool ScanProjectForSerializedTypes(out List<Type> serializedTypes)
+        public static bool ScanProjectForSerializedTypes(out List<Type> serializedTypes, bool scanBuildScenes = true, List<string> resourcesToScan = null, bool scanAllAssetBundles = true, bool scanPreloadedAssets = true)
         {
             using (var scanner = new AOTSupportScanner())
             {
                 scanner.BeginScan();
 
-                if (!scanner.ScanBuildScenes(includeSceneDependencies: true, showProgressBar: true))
+                if (scanBuildScenes && !scanner.ScanBuildScenes(includeSceneDependencies: true, showProgressBar: true))
                 {
                     Debug.Log("Project scan canceled while scanning scenes and their dependencies.");
                     serializedTypes = null;
                     return false;
                 }
 
-                if (!scanner.ScanAllResources(includeResourceDependencies: true, showProgressBar: true))
+                if (!scanner.ScanAllResources(includeResourceDependencies: true, showProgressBar: true, resourcesPaths: resourcesToScan))
                 {
                     Debug.Log("Project scan canceled while scanning resources and their depencencies.");
                     serializedTypes = null;
                     return false;
                 }
 
-                if (!scanner.ScanAllAssetBundles(showProgressBar: true))
+                if (scanAllAssetBundles && !scanner.ScanAllAssetBundles(showProgressBar: true))
                 {
                     Debug.Log("Project scan canceled while scanning asset bundles and their depencencies.");
                     serializedTypes = null;
                     return false;
                 }
 
-                if (!scanner.ScanPreloadedAssets(showProgressBar: true))
+                if (scanPreloadedAssets && !scanner.ScanPreloadedAssets(showProgressBar: true))
                 {
                     Debug.Log("Project scan canceled while scanning preloaded assets and their depencencies.");
                     serializedTypes = null;


### PR DESCRIPTION
## Problem
The current implementation of ScanProjectForSerializedTypes() always scans the whole project. It's usually acceptable for most projects, but in some cases the time consumption can make it unusable.

## Proposed changes
This PR adds some arguments to specify which scanning methods should be used. Additionally, a list of paths can be provided for the general resources scan.

## Results
In an extreme case, we have a production Unity project that takes 3.5 minutes to build, but just the Odin scan takes more than 11 minutes. With these changes and with the proper configuration (disabling "scan build scenes", disabling "scan all resources" and providing a list of paths tailored to the project), we reduced the scan from 11 minutes to 2 seconds.

## Further changes
I have some extra changes which add support for these options to the Odin Inspector:
![Captura de pantalla 2019-03-18 a las 19 34 54](https://user-images.githubusercontent.com/32454050/54554546-f5e6df00-49b4-11e9-96f0-9c67ce7d4842.png)
As I understand it, the source code of Odin Inspector isn't public, so I'd like to know the standard procedure for sending patches.