### PR TITLE
Fixes #10 Assertion error : During asset editing no new scenes can be…

### DIFF
--- a/OdinSerializer/Unity Integration/AOTSupportScanner.cs
+++ b/OdinSerializer/Unity Integration/AOTSupportScanner.cs
@@ -291,7 +291,11 @@ namespace OdinSerializer.Editor
                     try
                     {
                         Debug.unityLogger.logEnabled = false;
+                        AssetDatabase.StopAssetEditing();
+                        AssetDatabase.StopAssetEditing();
                         EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                        AssetDatabase.StartAssetEditing();
+                        AssetDatabase.StartAssetEditing();
                     }
                     catch { }
                     finally
@@ -304,7 +308,11 @@ namespace OdinSerializer.Editor
                     try
                     {
                         Debug.logger.logEnabled = false;
+                        AssetDatabase.StopAssetEditing();
+                        AssetDatabase.StopAssetEditing();
                         EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                        AssetDatabase.StartAssetEditing();
+                        AssetDatabase.StartAssetEditing();
                     }
                     catch { } 
                     finally


### PR DESCRIPTION
… created thus the assertion fails.

Stopping and restarting the assetdatabase editing before/after the new scene creating resolves #10 