### PR TITLE
[Fix] Fixed the case where JSON serialized string writing could over…

### DIFF
--- a/OdinSerializer/Core/DataReaderWriters/Json/JsonDataWriter.cs
+++ b/OdinSerializer/Core/DataReaderWriters/Json/JsonDataWriter.cs
@@ -676,6 +676,8 @@ namespace OdinSerializer
                     continue;
                 }
 
+                this.EnsureBufferSpace(2);
+
                 // Escape any characters that need to be escaped, default to no escape
                 switch (c)
                 {


### PR DESCRIPTION
…run the buffer when they contained characters that needed to be escaped